### PR TITLE
Pulls the inference_address from the lease.

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -17,9 +17,7 @@ class StreamingClient(client.Client):
         api_key: str,
         buffer_byte_size: int = 10485760,
     ):
-        advanced = client.Client.AdvancedOptions(
-            grpc_addr="prod.turbo.play.ht:443")
-        super().__init__(user_id, api_key, advanced=advanced)
+        super().__init__(user_id, api_key)
         self._buff_size = buffer_byte_size
 
     def play(self, text: str, voice: str, quality: str):

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -105,7 +105,7 @@ class Client:
             if self._lease and self._lease.expires > datetime.now() + timedelta(minutes=5):
                 return
             self._lease = self._get_lease()
-            grpc_addr = self._grpc_addr or self._lease.metadata["pigeon_url"]
+            grpc_addr = self._grpc_addr or self._lease.metadata["inference_address"]
             if self._rpc and self._rpc[0] != grpc_addr:
                 self._rpc[1].close()
                 self._rpc = None


### PR DESCRIPTION
Tested locally, works (or at least doesn't try to call pigeon anymore.)