### PR TITLE
Add on_prem_endpoint as an advanced option for sync and async pyht clients

### DIFF
--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -99,7 +99,7 @@ class AsyncClient:
 
             if self._advanced.on_prem_endpoint and self._advanced.on_prem_fallback and grpc_addr != fallback_addr:
                 if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
-                    self._fallback_rpc[1].close()
+                    await self._fallback_rpc[1].close()
                     self._fallback_rpc = None
                 if not self._fallback_rpc:
                     channel = (

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -166,18 +166,15 @@ class AsyncClient:
             error_code = getattr(e, "code")()
             if error_code not in {StatusCode.RESOURCE_EXHAUSTED, StatusCode.UNAVAILABLE} or self._fallback_rpc is None:
                 raise
-            if self._fallback_rpc is not None:
-                try:
-                    stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
-                    stream: TtsUnaryStream = stub.Tts(request)
-                    if context is not None:
-                        context.assign(stream)
-                    async for response in stream:
-                        yield response.data
-                except grpc.RpcError as fallback_e:
-                    raise fallback_e from e
-            else:
-                raise
+            try:
+                stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
+                stream: TtsUnaryStream = stub.Tts(request)
+                if context is not None:
+                    context.assign(stream)
+                async for response in stream:
+                    yield response.data
+            except grpc.RpcError as fallback_e:
+                raise fallback_e from e
 
     def get_stream_pair(
         self,

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -158,7 +158,11 @@ class AsyncClient:
                 yield response.data
         except grpc.RpcError as e:
             error_code = getattr(e, "code")()
-            if (error_code is grpc.StatusCode.RESOURCE_EXHAUSTED or error_code is grpc.StatusCode.UNAVAILABLE) and self._fallback_rpc:
+            should_fallback = (
+                    error_code is grpc.StatusCode.RESOURCE_EXHAUSTED
+                    or error_code is grpc.StatusCode.UNAVAILABLE
+            )
+            if should_fallback and self._fallback_rpc:
                 stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
                 stream: TtsUnaryStream = stub.Tts(request)
                 if context is not None:

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -96,8 +96,13 @@ class AsyncClient:
                 )
                 self._rpc = (grpc_addr, channel)
 
+            # Maybe set up a fallback grpc client
             if self._advanced.fallback_enabled:
+                # Choose the fallback address
+                # For now, this always is the inference address in the lease, but we can extend in the future
                 fallback_addr = self._lease.metadata["inference_address"]
+
+                # Only do fallback if the fallback address is not the same as the primary address
                 if grpc_addr != fallback_addr:
                     if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
                         await self._fallback_rpc[1].close()

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -41,9 +41,8 @@ class AsyncClient:
         api_url: str = "https://api.play.ht/api"
         grpc_addr: str | None = None
         insecure: bool = False
+        fallback_enabled: bool = False
         auto_refresh_lease: bool = True
-        on_prem_endpoint: str | None = None
-        on_prem_fallback: bool = True
 
     def __init__(
         self,
@@ -85,28 +84,30 @@ class AsyncClient:
             self._lease = await to_thread(self._lease_factory)
 
             grpc_addr = self._advanced.grpc_addr or self._lease.metadata["inference_address"]
-            fallback_addr = self._lease.metadata["inference_address"]
 
             if self._rpc and self._rpc[0] != grpc_addr:
                 await self._rpc[1].close()
                 self._rpc = None
             if self._rpc is None:
+                insecure = self._advanced.insecure or "on-prem.play.ht" in grpc_addr
                 channel = (
-                    insecure_channel(grpc_addr) if self._advanced.on_prem_endpoint or self._advanced.insecure
+                    insecure_channel(grpc_addr) if insecure
                     else secure_channel(grpc_addr, ssl_channel_credentials())
                 )
                 self._rpc = (grpc_addr, channel)
 
-            if self._advanced.on_prem_endpoint and self._advanced.on_prem_fallback and grpc_addr != fallback_addr:
-                if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
-                    await self._fallback_rpc[1].close()
-                    self._fallback_rpc = None
-                if not self._fallback_rpc:
-                    channel = (
-                        insecure_channel(fallback_addr) if self._advanced.insecure
-                        else secure_channel(fallback_addr, ssl_channel_credentials())
-                    )
-                    self._fallback_rpc = (fallback_addr, channel)
+            if self._advanced.fallback_enabled:
+                fallback_addr = self._lease.metadata["inference_address"]
+                if grpc_addr != fallback_addr:
+                    if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
+                        await self._fallback_rpc[1].close()
+                        self._fallback_rpc = None
+                    if not self._fallback_rpc:
+                        channel = (
+                            insecure_channel(fallback_addr) if self._advanced.insecure
+                            else secure_channel(fallback_addr, ssl_channel_credentials())
+                        )
+                        self._fallback_rpc = (fallback_addr, channel)
 
     async def stream_tts_input(
         self,

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -64,7 +64,7 @@ class Client:
         insecure: bool = False
         auto_refresh_lease: bool = True
         on_prem_endpoint: str | None = None
-        on_prem_fallback: bool = False
+        on_prem_fallback: bool = True
 
     def __init__(
         self,
@@ -183,7 +183,8 @@ class Client:
             for item in response:
                 yield item.data
         except grpc.RpcError as e:
-            if (e.code() == grpc.StatusCode.RESOURCE_EXHAUSTED or e.code() == grpc.StatusCode.UNAVAILABLE) and self._fallback_rpc:
+            error_code = getattr(e, "code")()
+            if (error_code is grpc.StatusCode.RESOURCE_EXHAUSTED or error_code is grpc.StatusCode.UNAVAILABLE) and self._fallback_rpc:
                 stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
                 response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
                 for item in response:

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -8,6 +8,7 @@ import io
 import queue
 import threading
 
+import grpc
 from grpc import Channel, insecure_channel, secure_channel, ssl_channel_credentials
 
 from .lease import Lease, LeaseFactory
@@ -62,6 +63,8 @@ class Client:
         grpc_addr: str | None = None
         insecure: bool = False
         auto_refresh_lease: bool = True
+        on_prem_endpoint: str | None = None
+        on_prem_fallback: bool = False
 
     def __init__(
         self,
@@ -78,6 +81,7 @@ class Client:
         self._lease_factory = LeaseFactory(user_id, api_key, self._advanced.api_url)
         self._lease: Lease | None = None
         self._rpc: Tuple[str, Channel] | None = None
+        self._fallback_rpc: Tuple[str, Channel] | None = None
         self._lock = threading.Lock()
         self._timer: threading.Timer | None = None
         if auto_connect:
@@ -102,17 +106,33 @@ class Client:
                     self._schedule_refresh()
                 return
             self._lease = self._lease_factory()
-            grpc_addr = self._advanced.grpc_addr or self._lease.metadata["inference_address"]
+
+            grpc_addr = self._advanced.on_prem_endpoint or self._advanced.grpc_addr or self._lease.metadata["inference_address"]
+            fallback_addr = self._lease.metadata["inference_address"]
+
             if self._rpc and self._rpc[0] != grpc_addr:
                 self._rpc[1].close()
                 self._rpc = None
             if not self._rpc:
                 channel = (
                     insecure_channel(grpc_addr)
-                    if self._advanced.insecure
+                    if self._advanced.on_prem_endpoint or self._advanced.insecure
                     else secure_channel(grpc_addr, ssl_channel_credentials())
                 )
                 self._rpc = (grpc_addr, channel)
+
+            if self._advanced.on_prem_endpoint and self._advanced.on_prem_fallback and grpc_addr != fallback_addr:
+                if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
+                    self._fallback_rpc[1].close()
+                    self._fallback_rpc = None
+                if not self._fallback_rpc:
+                    channel = (
+                        insecure_channel(fallback_addr)
+                        if self._advanced.insecure
+                        else secure_channel(fallback_addr, ssl_channel_credentials())
+                    )
+                    self._fallback_rpc = (fallback_addr, channel)
+
             if self._timer:
                 self._timer.cancel()
 
@@ -157,10 +177,20 @@ class Client:
         text = ensure_sentence_end(text)
 
         request = api_pb2.TtsRequest(params=options.tts_params(text, voice_engine), lease=lease_data)
-        stub = api_pb2_grpc.TtsStub(self._rpc[1])
-        response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
-        for item in response:
-            yield item.data
+        try:
+            stub = api_pb2_grpc.TtsStub(self._rpc[1])
+            response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
+            for item in response:
+                yield item.data
+        except grpc.RpcError as e:
+            if (e.code() == grpc.StatusCode.RESOURCE_EXHAUSTED or e.code() == grpc.StatusCode.UNAVAILABLE) and self._fallback_rpc:
+                stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
+                response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
+                for item in response:
+                    yield item.data
+            else:
+                raise
+
 
     def get_stream_pair(
         self,
@@ -184,6 +214,9 @@ class Client:
         if self._rpc:
             self._rpc[1].close()
             self._rpc = None
+        if self._fallback_rpc:
+            self._fallback_rpc[1].close()
+            self._fallback_rpc = None
 
     def __del__(self):
         self.close()

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -119,8 +119,13 @@ class Client:
                 )
                 self._rpc = (grpc_addr, channel)
 
+            # Maybe set up a fallback grpc client
             if self._advanced.fallback_enabled:
+                # Choose the fallback address
+                # For now, this always is the inference address in the lease, but we can extend in the future
                 fallback_addr = self._lease.metadata["inference_address"]
+
+                # Only do fallback if the fallback address is not the same as the primary address
                 if grpc_addr != fallback_addr:
                     if self._fallback_rpc and self._fallback_rpc[0] != fallback_addr:
                         self._fallback_rpc[1].close()

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -190,16 +190,13 @@ class Client:
             error_code = getattr(e, "code")()
             if error_code not in {StatusCode.RESOURCE_EXHAUSTED, StatusCode.UNAVAILABLE} or self._fallback_rpc is None:
                 raise
-            if self._fallback_rpc is not None:
-                try:
-                    stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
-                    response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
-                    for item in response:
-                        yield item.data
-                except grpc.RpcError as fallback_e:
-                    raise fallback_e from e
-            else:
-                raise
+            try:
+                stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
+                response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]
+                for item in response:
+                    yield item.data
+            except grpc.RpcError as fallback_e:
+                raise fallback_e from e
 
     def get_stream_pair(
         self,


### PR DESCRIPTION
Add on_prem_endpoint as an advanced option for sync and async pyht clients

Customers will now set AdvancedOptions.on_prem_endpoint="customer-name.on-prem.play.ht:11045" instead of setting grpc_addr="customer-name.on-prem.play.ht:11045" and insecure=True.

Add a fallback option (default is on) so that TTS requests to an on-prem appliance that is over capacity or down can fallback to the shared PlayHT endpoint.

So, client configuration goes from:

```
client = Client( 
  user_id="<YOUR_USER_ID>", 
  api_key="<YOUR_API_KEY>", 
  advanced=client.Client.AdvancedOptions(grpc_addr="customer-name-00000001.on-prem.play.ht:11045", insecure=True)
)
```

..to:

```
client = Client( 
  user_id="<YOUR_USER_ID>", 
  api_key="<YOUR_API_KEY>", 
  advanced=client.Client.AdvancedOptions(on_prem_endpoint="customer-name-00000001.on-prem.play.ht:11045")
)
```

Customers that don't want the fallback option can do the following:

```
client = Client( 
  user_id="<YOUR_USER_ID>", 
  api_key="<YOUR_API_KEY>", 
  advanced=client.Client.AdvancedOptions(on_prem_endpoint="customer-name-00000001.on-prem.play.ht:11045", on_prem_fallback=False)
)
```