### PR TITLE
Introduce configurable congestion control.

### DIFF
--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -225,6 +225,7 @@ class AsyncClient:
                     context.assign(stream)
                 async for response in stream:
                     yield response.data
+                break
             except grpc.RpcError as e:
                 error_code = getattr(e, "code")()
                 logging.debug(f"Error: {error_code}")

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -67,11 +67,15 @@ class CongestionCtrl(Enum):
     Enumerates a streaming congestion control algorithms, used to optimize the rate at which text is sent to PlayHT.
     """
 
-    # The client will not do any congestion control.  Text will be sent to PlayHT as fast as possible.
+    # The client will not do any congestion control.
     OFF = 0
 
-    # The client will optimize for minimizing the number of physical resources required to handle a single stream.
-    # If you're using PlayHT On-Prem, you should use this {@link CongestionCtrl} algorithm.
+    # The client will retry requests to the primary address up to two times with a 50ms backoff between attempts.
+    #
+    # Then it will fall back to the fallback address (if one is configured).  No retry attempts will be made
+    # against the fallback address.
+    #
+    # If you're using PlayHT On-Prem, you should probably be using this congestion control algorithm.
     STATIC_MAR_2023 = 1
 
 

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -271,8 +271,8 @@ class Client:
 
                 if retries < max_retries:
                     retries += 1
+                    # It's a poor customer experience to show internal details about retries, so we only debug log here.
                     logging.debug(f"Retrying in {backoff} ms ({retries} attempts so far)...  ({error_code})")
-                    print(f"Retrying in {backoff} ms ({retries} attempts so far)...  ({error_code})")
                     if backoff > 0:
                         time.sleep(backoff)
                     continue
@@ -280,8 +280,9 @@ class Client:
                 if self._fallback_rpc is None:
                     raise
 
+                # We log fallbacks to give customers an extra signal that they should scale up their on-prem appliance
+                # (e.g. by paying for more GPU quota)
                 logging.info(f"Falling back to {self._fallback_rpc[0]}... ({error_code})")
-                print(f"Falling back to {self._fallback_rpc[0]}... ({error_code})")
                 try:
                     stub = api_pb2_grpc.TtsStub(self._fallback_rpc[1])
                     response = stub.Tts(request)  # type: Iterable[api_pb2.TtsResponse]


### PR DESCRIPTION
The primary motivation for this (as of 2024/02/28) is increase availability for customers using PlayHT On-Prem appliance by adding quick retries in response to RESOURCE_EXHAUSTED errors.

This change allows customers to turn on one of an enumerated set of congestion control algorithms.  We've implemented just one for now, STATIC_MAR_2024, which retries at most twice with a 50ms backoff between attempts. This is a dead simple congestion control algorithm with static constants; it leaves a lot to be desired.  We should iterate on these algorithms in the future.  The CongestionCtrl enum was added so that algorithms can be added without requiring customers to change their code much.

See the analogous change in the NodeJs SDK here: https://github.com/playht/playht-nodejs-sdk/pull/31