### PR TITLE
Change gRPC voice engine default, clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# PlayHT API SDK
+# Play API SDK
 
-**pyht** is a Python SDK for [PlayHT's AI Text-to-Speech API](https://play.ht/text-to-speech-api/). PlayHT builds conversational voice AI models for realtime use cases. With **pyht**, you can easily convert text into high-quality audio streams with humanlike voices.
+**pyht** is a Python SDK for [Play's AI Text-to-Speech API](https://play.ht/text-to-speech-api/). Play builds conversational voice AI models for realtime use cases. With **pyht**, you can easily convert text into high-quality audio streams with humanlike voices.
 
-Currently the library supports only streaming text-to-speech. For the full set of functionalities provided by the PlayHT API such as [Voice Cloning](https://docs.play.ht/reference/api-create-instant-voice-clone), see the [PlayHT docs](https://docs.play.ht/reference/api-getting-started)
+Currently the library supports only streaming text-to-speech. For the full set of functionalities provided by the Play API such as [Voice Cloning](https://docs.play.ht/reference/api-create-instant-voice-clone), see the [Play docs](https://docs.play.ht/reference/api-getting-started)
 
 ## Features
 
 - Stream text-to-speech in real-time, synchronous or asynchronous.
-- Use PlayHT's pre-built voices or create custom voice clones.
+- Use Play's pre-built voices or create custom voice clones.
 - Stream text from LLM, and generate audio stream in real-time.
 - Supports WAV, MP3, Mulaw, FLAC, and OGG audio formats as well as raw audio.
 - Supports 8KHz, 16KHz, 24KHz, 44.1KHz and 48KHz sample rates.
@@ -80,9 +80,10 @@ The `tts` method takes the following arguments:
 - `options`: The options to use for the TTS request.
     - a `TTSOptions` object (see below).
 - `voice_engine`: The voice engine to use for the TTS request.
-    - `Play3.0-mini-http` (default): Our latest multilingual model, streaming audio over HTTP. (NOTE that it is `Play` not `PlayHT` like previous voice engines)
-    - `Play3.0-mini-ws`: Our latest multilingual model, streaming audio over WebSockets. (NOTE that it is `Play` not `PlayHT` like previous voice engines)
-    - `Play3.0-mini-grpc`: Our latest multilingual model, streaming audio over gRPC.  Use this voice engine if you're using Play On-Prem. (NOTE that it is `Play` not `PlayHT` like previous voice engines)
+    - `Play3.0-mini` models: Our fast multilingual model. NOTE: it is `Play` not `PlayHT` like previous voice engines
+        - `Play3.0-mini-http` (default): Streaming audio over HTTP.
+        - `Play3.0-mini-ws`: Streaming audio over WebSockets.
+        - `Play3.0-mini-grpc`: Streaming audio over gRPC. NOTE: Use this voice engine ONLY if you're using Play On-Prem.
     - `PlayHT2.0-turbo`: Our legacy English-only model, streaming audio over gRPC.
 
 ### TTSOptions
@@ -107,7 +108,7 @@ The `TTSOptions` class is used to specify the options for the TTS request. It ha
 - `quality`: DEPRECATED (use sample rate to adjust audio quality)
 - `speed`: The speed of the audio to be returned, a float (default 1.0).
 - `seed`: Random seed to use for audio generation, an integer (default None, will be randomly generated).
-- The following options are inference-time hyperparameters of the text-to-speech model; if unset, the model will use default values chosen by PlayHT.
+- The following options are inference-time hyperparameters of the text-to-speech model; if unset, the model will use default values chosen by Play.
     - `temperature`: The temperature of the model, a float.
     - `top_p`: The top_p of the model, a float.
     - `text_guidance`: The text_guidance of the model, a float.

--- a/demo/main.py
+++ b/demo/main.py
@@ -176,10 +176,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--user", "-u", type=str, required=True, help="Your Play.ht User ID."
+        "--user", "-u", type=str, required=True, help="Your Play User ID."
     )
     parser.add_argument(
-        "--key", "-k", type=str, required=True, help="Your Play.ht API key."
+        "--key", "-k", type=str, required=True, help="Your Play API key."
     )
     parser.add_argument(
         "--voice",

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -186,7 +186,7 @@ class AsyncClient:
             await asyncio.sleep(refresh_time.total_seconds())
 
     async def refresh_lease(self):
-        """Manually refresh credentials with Play.ht."""
+        """Manually refresh credentials with Play."""
         async with self._lock:
             if self._lease and self._lease.expires > datetime.now() + timedelta(minutes=5):
                 # Lease is still valid for at least the next 5 minutes.
@@ -230,7 +230,7 @@ class AsyncClient:
         options: TTSOptions,
         voice_engine: str | None = None,
     ):
-        """Stream input to Play.ht via the text_stream object."""
+        """Stream input to Play via the text_stream object."""
         buffer = io.StringIO()
         async for text in text_stream:
             t = text.strip()
@@ -276,7 +276,7 @@ class AsyncClient:
     ) -> AsyncIterable[bytes]:
 
         if voice_engine is None:
-            voice_engine = "Play3.0-mini-grpc"
+            voice_engine = "PlayHT2.0-turbo"
         elif voice_engine != "Play3.0-mini-grpc" and voice_engine != "PlayHT2.0-turbo":
             raise ValueError("Only Play3.0-mini-grpc and PlayHT2.0-turbo are supported in the gRPC API")
 

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -173,11 +173,9 @@ class TTSOptions:
     def tts_params(self, text: list[str], voice_engine: str | None) -> api_pb2.TtsParams:
 
         if voice_engine is None:
-            voice_engine = "Play3.0-mini-grpc"
-        if voice_engine == "PlayHT2.0-turbo":
-            logging.warning("Voice engine PlayHT2.0-turbo is deprecated; use Play3.0-mini-grpc instead.")
-        elif voice_engine != "Play3.0-mini-grpc":
-            raise ValueError("Only Play3.0-mini-grpc is supported in the gRPC API")
+            voice_engine = "PlayHT2.0-turbo"
+        elif voice_engine != "Play3.0-mini-grpc" and voice_engine != "PlayHT2.0-turbo":
+            raise ValueError("Only PlayHT2.0-turbo and Play3.0-mini-grpc (on-prem only) are supported in the gRPC API")
 
         language_identifier = None
         if self.language is not None:
@@ -247,7 +245,7 @@ def http_prepare_dict(text: List[str], options: TTSOptions, voice_engine: str) -
 
 class CongestionCtrl(Enum):
     """
-    Enumerates a streaming congestion control algorithms, used to optimize the rate at which text is sent to PlayHT.
+    Enumerates a streaming congestion control algorithms, used to optimize the rate at which text is sent to Play.
     """
 
     # The client will not do any congestion control.
@@ -258,7 +256,7 @@ class CongestionCtrl(Enum):
     # Then it will fall back to the fallback address (if one is configured).  No retry attempts will be made
     # against the fallback address.
     #
-    # If you're using PlayHT On-Prem, you should probably be using this congestion control algorithm.
+    # If you're using Play On-Prem, you should probably be using this congestion control algorithm.
     STATIC_MAR_2023 = 1
 
 
@@ -443,7 +441,7 @@ class Client:
         options: TTSOptions,
         voice_engine: str | None = None
     ) -> Iterable[bytes]:
-        """Stream input to Play.ht via the text_stream object."""
+        """Stream input to Play via the text_stream object."""
         buffer = io.StringIO()
         for text in text_stream:
             t = text.strip()
@@ -486,7 +484,7 @@ class Client:
     ) -> Iterable[bytes]:
 
         if voice_engine is None:
-            voice_engine = "Play3.0-mini-grpc"
+            voice_engine = "PlayHT2.0-turbo"
         elif voice_engine != "Play3.0-mini-grpc" and voice_engine != "PlayHT2.0-turbo":
             raise ValueError("Only Play3.0-mini-grpc and PlayHT2.0-turbo are supported in the gRPC API")
 


### PR DESCRIPTION
* 3.0-mini-grpc is not available for non-on-prem customers; note this more clearly and don't default to it
* 2.0-turbo is not deprecated, many non-on-prem customers continue to use it
* Take this opportunity to update brand (PlayHT -> Play)