### PR TITLE
Fix bug in ensure_inference_coordinates()

### DIFF
--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -123,9 +123,9 @@ class AsyncClient:
             asyncio.ensure_future(self.warmup())
 
     async def ensure_inference_coordinates(self, force: bool = False):
-        if any([self._inference_coordinates is None,
-                self._inference_coordinates["refresh_at_ms"] < time.time_ns() // 1000000,  # pyright: ignore
-                force]):
+        if self._inference_coordinates is None or \
+                self._inference_coordinates["refresh_at_ms"] < time.time_ns() // 1000000 or \
+                force:
             if self._advanced.inference_coordinates_options.coordinates_generator_function_async is not None:
                 self._inference_coordinates = await self._advanced.inference_coordinates_options.\
                         coordinates_generator_function_async(self._user_id, self._api_key,

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -390,9 +390,9 @@ class Client:
             self.warmup()
 
     def ensure_inference_coordinates(self, force: bool = False):
-        if any([self._inference_coordinates is None,
-                self._inference_coordinates["refresh_at_ms"] < time.time_ns() // 1000000,  # pyright: ignore
-                force]):
+        if self._inference_coordinates is None or \
+                self._inference_coordinates["refresh_at_ms"] < time.time_ns() // 1000000 or \
+                force:
             if self._advanced.inference_coordinates_options.coordinates_generator_function is not None:
                 self._inference_coordinates = self._advanced.inference_coordinates_options.\
                     coordinates_generator_function(self._user_id, self._api_key,


### PR DESCRIPTION
If self.inference_coordinates is None, any() will throw an error (NoneType not subscriptable) on the second condition even if the first condition was met; with "or", the second condition will never be evaluated if the first is met.