### PR TITLE
Fall back to HTTP if protocol not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,14 @@ The `tts` method takes the following arguments:
 - `text`: The text to be converted to speech; a string or list of strings.
 - `options`: The options to use for the TTS request; a `TTSOptions` object [(see below)](#ttsoptions).
 - `voice_engine`: The voice engine to use for the TTS request; a string (default `Play3.0-mini-http`).
-    - `PlayDialog-*`: Our large, expressive English model, which also supports multi-turn two-speaker dialogues.
-        - `PlayDialog-http`: Streaming and non-streaming audio over HTTP.
-        - `PlayDialog-ws`: Streaming audio over WebSockets.
-    - `PlayDialogMultilingual-*`: Our large, expressive multilingual model, which also supports multi-turn two-speaker dialogues.
-        - `PlayDialogMultilingual-http`: Streaming and non-streaming audio over HTTP.
-        - `PlayDialogMultilingual-ws`: Streaming audio over WebSockets.
-    - `Play3.0-mini-*`: Our small, fast multilingual model.
-        - `Play3.0-mini-http`: Streaming and non-streaming audio over HTTP.
-        - `Play3.0-mini-ws`: Streaming audio over WebSockets.
-        - `Play3.0-mini-grpc`: Streaming audio over gRPC. NOTE: This voice engine is ONLY available for Play On-Prem customers.
-    - `PlayHT2.0-turbo`: Our legacy English-only model, streaming audio over gRPC.
+    - `PlayDialog`: Our large, expressive English model, which also supports multi-turn two-speaker dialogues.
+    - `PlayDialogMultilingual`: Our large, expressive multilingual model, which also supports multi-turn two-speaker dialogues.
+    - `Play3.0-mini`: Our small, fast multilingual model.
+    - `PlayHT2.0-turbo`: Our legacy English-only model
+- `protocol`: The protocol to use to communicate with the Play API (`http` by default except for `PlayHT2.0-turbo` which is `grpc` by default).
+    - `http`: Streaming and non-streaming audio over HTTP (supports `Play3.0-mini`, `PlayDialog`, and `PlayDialogMultilingual`).
+    - `ws`: Streaming audio over WebSockets (supports `Play3.0-mini`, `PlayDialog`, and `PlayDialogMultilingual`).
+    - `grpc`: Streaming audio over gRPC (supports `PlayHT2.0-turbo` for all, and `Play3.0-mini` ONLY for Play On-Prem customers).
 - `streaming`: Whether or not to stream the audio in chunks (default True); non-streaming is only enabled for HTTP endpoints.
 
 ### TTSOptions
@@ -117,12 +114,12 @@ The `TTSOptions` class is used to specify the options for the TTS request. It ha
 - The following options are inference-time hyperparameters of the text-to-speech model; if unset, the model will use default values chosen by Play.
     - `temperature` (all models): The temperature of the model, a float.
     - `top_p` (all models): The top_p of the model, a float.
-    - `text_guidance` (`Play3.0-mini-*` and `PlayHT2.0-turbo` only): The text_guidance of the model, a float.
-    - `voice_guidance` (`Play3.0-mini-*` and `PlayHT2.0-turbo` only): The voice_guidance of the model, a float.
-    - `style_guidance` (`Play3.0-mini-*` only): The style_guidance of the model, a float.
-    - `repetition_penalty` (`Play3.0-mini-*` and `PlayHT2.0-turbo` only): The repetition_penalty of the model, a float.
+    - `text_guidance` (`Play3.0-mini` and `PlayHT2.0-turbo` only): The text_guidance of the model, a float.
+    - `voice_guidance` (`Play3.0-mini` and `PlayHT2.0-turbo` only): The voice_guidance of the model, a float.
+    - `style_guidance` (`Play3.0-mini` only): The style_guidance of the model, a float.
+    - `repetition_penalty` (`Play3.0-mini` and `PlayHT2.0-turbo` only): The repetition_penalty of the model, a float.
 - `disable_stabilization` (`PlayHT2.0-turbo` only): Disable the audio stabilization process, a boolean (default `False`).
-- `language` (`Play3.0-*` and `PlayDialogMultilingual-*` only): The language of the text to be spoken, a `Language` enum value or `None` (default `ENGLISH`).
+- `language` (`Play3.0` and `PlayDialogMultilingual` only): The language of the text to be spoken, a `Language` enum value or `None` (default `ENGLISH`).
     - `AFRIKAANS`
     - `ALBANIAN`
     - `AMHARIC`
@@ -160,7 +157,7 @@ The `TTSOptions` class is used to specify the options for the TTS request. It ha
     - `UKRAINIAN`
     - `URDU`
     - `XHOSA`
-- The following options are additional inference-time hyperparameters which only apply to the `PlayDialog-*` and `PlayDialogMultilingual-*` models; if unset, the model will use default values chosen by Play.
+- The following options are additional inference-time hyperparameters which only apply to the `PlayDialog` and `PlayDialogMultilingual` models; if unset, the model will use default values chosen by Play.
     - `voice_2` (multi-turn dialogue only): The second voice to use for a multi-turn TTS request; a string.
         - A URL pointing to a Play voice manifest file.
     - `turn_prefix` (multi-turn dialogue only): The prefix for the first speaker's turns in a multi-turn TTS request; a string.

--- a/pyht/async_client.py
+++ b/pyht/async_client.py
@@ -26,7 +26,7 @@ from .inference_coordinates import get_coordinates_async, InferenceCoordinatesOp
 from .lease import Lease, LeaseFactory
 from .protos import api_pb2, api_pb2_grpc
 from .telemetry import Metrics, Telemetry
-from .utils import prepare_text, SENTENCE_END_REGEX
+from .utils import prepare_text, SENTENCE_END_REGEX, get_voice_engine_and_protocol
 
 
 TtsUnaryStream = UnaryStreamCall[api_pb2.TtsRequest, api_pb2.TtsResponse]
@@ -256,21 +256,7 @@ class AsyncClient:
     ) -> AsyncIterable[bytes]:
         metrics = self._telemetry.start("tts-request")
         try:
-            if voice_engine is None:
-                voice_engine = "Play3.0-mini"
-                protocol = "http"
-            elif voice_engine == "PlayHT2.0-turbo":
-                protocol = "grpc"
-            elif voice_engine == "Play3.0":
-                logging.warning("Voice engine Play3.0 is deprecated; use Play3.0-mini-http instead.")
-                voice_engine = "Play3.0-mini"
-                protocol = "http"
-            elif voice_engine == "Play3.0-ws":
-                logging.warning("Voice engine Play3.0-ws is deprecated; use Play3.0-mini-ws instead.")
-                voice_engine = "Play3.0-mini"
-                protocol = "ws"
-            else:
-                voice_engine, protocol = voice_engine.rsplit("-", 1)
+            voice_engine, protocol = get_voice_engine_and_protocol(voice_engine)
 
             if protocol == "http":
                 return self._tts_http(text, options, voice_engine, metrics, streaming)

--- a/pyht/client.py
+++ b/pyht/client.py
@@ -24,7 +24,7 @@ from .inference_coordinates import get_coordinates, InferenceCoordinatesOptions
 from .lease import Lease, LeaseFactory
 from .protos import api_pb2, api_pb2_grpc
 from .telemetry import Metrics, Telemetry
-from .utils import prepare_text, SENTENCE_END_REGEX
+from .utils import prepare_text, SENTENCE_END_REGEX, get_voice_engine_and_protocol
 
 
 CLIENT_RETRY_OPTIONS = [
@@ -531,21 +531,7 @@ class Client:
     ) -> Iterable[bytes]:
         metrics = self._telemetry.start("tts-request")
         try:
-            if voice_engine is None:
-                voice_engine = "Play3.0-mini"
-                protocol = "http"
-            elif voice_engine == "PlayHT2.0-turbo":
-                protocol = "grpc"
-            elif voice_engine == "Play3.0":
-                logging.warning("Voice engine Play3.0 is deprecated; use Play3.0-mini-http instead.")
-                voice_engine = "Play3.0-mini"
-                protocol = "http"
-            elif voice_engine == "Play3.0-ws":
-                logging.warning("Voice engine Play3.0-ws is deprecated; use Play3.0-mini-ws instead.")
-                voice_engine = "Play3.0-mini"
-                protocol = "ws"
-            else:
-                voice_engine, protocol = voice_engine.rsplit("-", 1)
+            voice_engine, protocol = get_voice_engine_and_protocol(voice_engine)
 
             if protocol == "http":
                 return self._tts_http(text, options, voice_engine, metrics, streaming)

--- a/pyht/utils.py
+++ b/pyht/utils.py
@@ -15,30 +15,143 @@ def prepare_text(text: Union[str, List[str]], remove_ssml_tags: bool = True) -> 
     return text
 
 
-def get_voice_engine_and_protocol(voice_engine: Optional[str]) -> Tuple[str, str]:
-    if voice_engine is None:
-        logging.warning("No voice engine specified; using Play3.0-mini-http")
-        voice_engine = "Play3.0-mini"
-        protocol = "http"
-    elif voice_engine == "PlayHT2.0-turbo":
-        protocol = "grpc"
-    elif voice_engine == "Play3.0":
-        logging.warning("Voice engine Play3.0 is deprecated; use Play3.0-mini-http or Play3.0-mini-ws instead.")
-        logging.warning("No protocol specified; using HTTP (if not desired, append '-ws' to the voice engine)")
-        voice_engine = "Play3.0-mini"
-        protocol = "http"
-    elif voice_engine == "Play3.0-http":
-        logging.warning("Voice engine Play3.0-http is deprecated; use Play3.0-mini-http instead.")
-        voice_engine = "Play3.0-mini"
-        protocol = "http"
-    elif voice_engine == "Play3.0-ws":
-        logging.warning("Voice engine Play3.0-ws is deprecated; use Play3.0-mini-ws instead.")
-        voice_engine = "Play3.0-mini"
-        protocol = "ws"
-    elif voice_engine == "Play3.0-mini" or voice_engine == "PlayDialog" or voice_engine == "PlayDialogMultilingual":
-        logging.warning("No protocol specified; using HTTP (if not desired, append '-ws' to the voice engine)")
-        protocol = "http"
+def _convert_deprecated_voice_engine(voice_engine: str, protocol: Optional[str]) -> Tuple[str, str]:
+    _voice_engine, _protocol = voice_engine.rsplit("-", 1)
+    if not protocol or protocol == _protocol:
+        logging.warning(f"Voice engine {_voice_engine}-{_protocol} is deprecated; \
+                        separately pass voice_engine='{_voice_engine}' and protocol='{_protocol}'.")
+        return _voice_engine, _protocol
     else:
-        voice_engine, protocol = voice_engine.rsplit("-", 1)
+        raise ValueError(f"Got voice engine of deprecated format {voice_engine} \
+                         as well as mismatched protocol {protocol}.")
+
+
+def get_voice_engine_and_protocol(voice_engine: Optional[str], protocol: Optional[str]) -> Tuple[str, str]:
+    if protocol and protocol not in ["http", "ws", "grpc"]:
+        raise ValueError(f"Invalid protocol: {protocol} (must be http, ws, or grpc).")
+
+    # this is a bunch of tedious backward compatibility
+
+    if not voice_engine:
+        if not protocol:
+            logging.warning("No voice engine or protocol specified; using Play3.0-mini-http.")
+            voice_engine = "Play3.0-mini"
+            protocol = "http"
+        elif protocol in ["http", "ws"]:
+            logging.warning(f"No voice engine specified and protocol is {protocol}; using Play3.0-mini-{protocol}.")
+            voice_engine = "Play3.0-mini"
+        elif protocol == "grpc":
+            logging.warning("No voice engine specified and protocol is grpc; using PlayHT2.0-turbo.")
+            voice_engine = "PlayHT2.0-turbo"
+        else:
+            raise ValueError(f"No voice engine specified and invalid protocol {protocol} (must be http, ws, or grpc).")
+
+    elif voice_engine == "PlayHT2.0-turbo":
+        if not protocol:
+            protocol = "grpc"
+        if protocol != "grpc":
+            raise ValueError(f"Voice engine PlayHT2.0-turbo does not support protocol {protocol} (must be grpc).")
+
+    elif voice_engine in ["Play3.0-mini", "Play3.0-mini-http", "Play3.0-mini-ws", "Play3.0-mini-grpc",
+                          "Play3.0", "Play3.0-http", "Play3.0-ws", "Play3.0-grpc"]:
+        if "mini" not in voice_engine:
+            logging.warning("Voice engine Play3.0 is deprecated; use Play3.0-mini.")
+            voice_engine = voice_engine.replace("Play3.0", "Play3.0-mini")
+        if voice_engine == "Play3.0-mini":
+            if not protocol:
+                logging.warning("No protocol specified; using http")
+                protocol = "http"
+            if protocol not in ["http", "ws", "grpc"]:
+                raise ValueError(f"Voice engine Play3.0-mini does not support protocol {protocol} \
+                                 (must be http, ws, or grpc [grpc for on-prem customers only]).")
+        else:
+            voice_engine, protocol = _convert_deprecated_voice_engine(voice_engine, protocol)
+
+    elif voice_engine in ["PlayDialog", "PlayDialog-http", "PlayDialog-ws", "PlayDialogMultilingual",
+                          "PlayDialogMultilingual-http", "PlayDialogMultilingual-ws"]:
+        if voice_engine in ["PlayDialog", "PlayDialogMultilingual"]:
+            if not protocol:
+                logging.warning("No protocol specified; using http")
+                protocol = "http"
+            if protocol not in ["http", "ws"]:
+                raise ValueError(f"Voice engine {voice_engine} does not support protocol {protocol} \
+                                 (must be http or ws).")
+        else:
+            voice_engine, protocol = _convert_deprecated_voice_engine(voice_engine, protocol)
+
+    else:
+        raise ValueError(f"Invalid voice engine: {voice_engine} (must be Play3.0-mini, PlayDialog, \
+                         PlayDialogMultilingual, or PlayHT2.0-turbo).")
 
     return voice_engine, protocol
+
+
+def main():
+    assert get_voice_engine_and_protocol(None, "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("", "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol(None, "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("", "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol(None, None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("", None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol(None, "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("", "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini", "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini", "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-mini", "grpc") == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0-mini", None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini", "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini-http", "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini-http", None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini-http", "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-mini-ws", "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-mini-ws", None) == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-mini-ws", "") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-mini-grpc", "grpc") == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0-mini-grpc", None) == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0-mini-grpc", "") == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0", "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0", "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0", "grpc") == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0", None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0", "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-http", "http") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-http", None) == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-http", "") == ("Play3.0-mini", "http")
+    assert get_voice_engine_and_protocol("Play3.0-ws", "ws") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-ws", None) == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-ws", "") == ("Play3.0-mini", "ws")
+    assert get_voice_engine_and_protocol("Play3.0-grpc", "grpc") == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0-grpc", None) == ("Play3.0-mini", "grpc")
+    assert get_voice_engine_and_protocol("Play3.0-grpc", "") == ("Play3.0-mini", "grpc")
+
+    assert get_voice_engine_and_protocol("PlayDialog", "http") == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog", "ws") == ("PlayDialog", "ws")
+    assert get_voice_engine_and_protocol("PlayDialog", None) == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog", "") == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog-http", "http") == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog-http", None) == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog-http", "") == ("PlayDialog", "http")
+    assert get_voice_engine_and_protocol("PlayDialog-ws", "ws") == ("PlayDialog", "ws")
+    assert get_voice_engine_and_protocol("PlayDialog-ws", None) == ("PlayDialog", "ws")
+    assert get_voice_engine_and_protocol("PlayDialog-ws", "") == ("PlayDialog", "ws")
+
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual", "http") == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual", "ws") == ("PlayDialogMultilingual", "ws")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual", None) == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual", "") == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-http", "http") == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-http", None) == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-http", "") == ("PlayDialogMultilingual", "http")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-ws", "ws") == ("PlayDialogMultilingual", "ws")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-ws", None) == ("PlayDialogMultilingual", "ws")
+    assert get_voice_engine_and_protocol("PlayDialogMultilingual-ws", "") == ("PlayDialogMultilingual", "ws")
+
+    assert get_voice_engine_and_protocol(None, "grpc") == ("PlayHT2.0-turbo", "grpc")
+    assert get_voice_engine_and_protocol("", "grpc") == ("PlayHT2.0-turbo", "grpc")
+    assert get_voice_engine_and_protocol("PlayHT2.0-turbo", "grpc") == ("PlayHT2.0-turbo", "grpc")
+    assert get_voice_engine_and_protocol("PlayHT2.0-turbo", None) == ("PlayHT2.0-turbo", "grpc")
+    assert get_voice_engine_and_protocol("PlayHT2.0-turbo", "") == ("PlayHT2.0-turbo", "grpc")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyht/utils.py
+++ b/pyht/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import logging
 import re
-from typing import List, Union
+from typing import List, Union, Tuple, Optional
 
 SENTENCE_END_REGEX = re.compile('.*[-.!?;:…]$')
 
@@ -12,3 +13,32 @@ def prepare_text(text: Union[str, List[str]], remove_ssml_tags: bool = True) -> 
     if remove_ssml_tags:
         text = [re.sub(r'<[^>]*>', '', x) for x in text]
     return text
+
+
+def get_voice_engine_and_protocol(voice_engine: Optional[str]) -> Tuple[str, str]:
+    if voice_engine is None:
+        logging.warning("No voice engine specified; using Play3.0-mini-http")
+        voice_engine = "Play3.0-mini"
+        protocol = "http"
+    elif voice_engine == "PlayHT2.0-turbo":
+        protocol = "grpc"
+    elif voice_engine == "Play3.0":
+        logging.warning("Voice engine Play3.0 is deprecated; use Play3.0-mini-http or Play3.0-mini-ws instead.")
+        logging.warning("No protocol specified; using HTTP (if not desired, append '-ws' to the voice engine)")
+        voice_engine = "Play3.0-mini"
+        protocol = "http"
+    elif voice_engine == "Play3.0-http":
+        logging.warning("Voice engine Play3.0-http is deprecated; use Play3.0-mini-http instead.")
+        voice_engine = "Play3.0-mini"
+        protocol = "http"
+    elif voice_engine == "Play3.0-ws":
+        logging.warning("Voice engine Play3.0-ws is deprecated; use Play3.0-mini-ws instead.")
+        voice_engine = "Play3.0-mini"
+        protocol = "ws"
+    elif voice_engine == "Play3.0-mini" or voice_engine == "PlayDialog" or voice_engine == "PlayDialogMultilingual":
+        logging.warning("No protocol specified; using HTTP (if not desired, append '-ws' to the voice engine)")
+        protocol = "http"
+    else:
+        voice_engine, protocol = voice_engine.rsplit("-", 1)
+
+    return voice_engine, protocol


### PR DESCRIPTION
This is ugly but will hopefully reduce customer confusion. Instead of passing voice engine as `PlayDialog-ws` or `-http` etc, the protocol is now a separate argument, but we keep backward compatibility (and log a warning).