### PR TITLE
GitHub workflow: specify Ubuntu 22.04 LTS to avoid Git issue with poetry-publish action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Build and publish to pypi


### PR DESCRIPTION
We got a [deployment action failure](https://github.com/playht/pyht/actions/runs/12800259114/job/35687730173) because [github bumped ubuntu-latest to 24.04](https://github.com/actions/runner-images/issues/10636). The workarounds for this seem pretty annoying so I am just going to roll the action back to 22.04 as it will be supported for 2 more years.

Specifically, this "helpful security check" in git was [introduced in 2.35.2](https://github.com/actions/runner-images/issues/6775#issuecomment-1352973077). Ubuntu 22.04 has git 2.25.1 while 22.04 has git 2.45.2: https://launchpad.net/ubuntu/+source/git